### PR TITLE
feat(snap): add NewClient with client key verification at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,38 +76,24 @@ privateKey := "YOUR_PRIVATE_KEY"
 publicKey := "YOUR_PUBLIC_KEY"
 clientId := "YOUR_CLIENT_ID"
 secretKey := "YOUR_SECRET_KEY"
-isProduction := false
 issuer := "YOUR_ISSUER"
 
-doku.TokenController = controllers.TokenController{}
-doku.VaController = controllers.VaController{}
-doku.NotificationController = controllers.NotificationController{}
-doku.DirectDebitController = &controllers.DirectDebitController{}
 
-var snap doku.Snap
-snap = doku.Snap{
-    PrivateKey:   privateKey,
-    ClientId:     clientId,
-    IsProduction: isProduction,
-    SecretKey:    secretKey,
-    Issuer: 	  issuer,
-    PublicKey:    publicKey,
+client, err := doku.NewClient(privateKey, publicKey, secretKey, clientId, doku.ProductionEnv(), doku.WithIssuer(issuer))
+if err != nil{
+  return err
 }
 ```
 
 ## 2. Usage
 
 **Initialization**
-Always start by initializing the Snap object.
+Always start by initializing the Snap client:
 
 ```go
-snap = doku.Snap{
-    PrivateKey:   privateKey,
-    ClientId:     clientId,
-    IsProduction: isProduction,
-    SecretKey:    secretKey,
-    Issuer: 	  issuer,
-    PublicKey:    publicKey,
+client, err := doku.NewClient(privateKey, publicKey, secretKey, clientId, doku.ProductionEnv(), doku.WithIssuer(issuer))
+if err != nil{
+  return err
 }
 ```
 ### Virtual Account

--- a/controllers/tokenController.go
+++ b/controllers/tokenController.go
@@ -1,6 +1,14 @@
 package controllers
 
 import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/PTNUSASATUINTIARTHA-DOKU/doku-golang-library/commons/utils"
@@ -11,6 +19,7 @@ import (
 )
 
 type TokenControllerInterface interface {
+	VerifyClientKey(privateKey, clientID string) error
 	GetTokenB2B(privateKey string, clientId string, isProduction bool) tokenModels.TokenB2BResponseDTO
 	GetTokenB2B2C(authCode string, privateKey string, clientId string, isProduction bool) (tokenModels.TokenB2B2CResponseDTO, error)
 	IsTokenInvalid(tokenB2B string, tokenExpiresIn int, tokenGeneratedTimestamp string) bool
@@ -25,6 +34,44 @@ var TokenServices services.TokenServices
 var SnapUtils utils.SnapUtils
 
 type TokenController struct{}
+
+func (tc TokenController) VerifyClientKey(privateKey, clientID string) error {
+	block, _ := pem.Decode([]byte(privateKey))
+	if block == nil {
+		return errors.New("failed to decode PEM block containing private key")
+	}
+
+	var (
+		rsaPrivateKey *rsa.PrivateKey
+		err           error
+	)
+
+	switch block.Type {
+	case "PRIVATE KEY":
+		privateKey, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return err
+		}
+
+		var ok bool
+		if rsaPrivateKey, ok = privateKey.(*rsa.PrivateKey); !ok {
+			return errors.New("not an RSA private key")
+		}
+	case "RSA PRIVATE KEY":
+		if rsaPrivateKey, err = x509.ParsePKCS1PrivateKey(block.Bytes); err != nil {
+			return err
+		}
+	default:
+		return errors.New("unsupported private key type")
+	}
+
+	hashed := sha256.Sum256(fmt.Appendf(nil, "%s|%s", clientID, TokenServices.GenerateTimestamp()))
+	if _, err := rsa.SignPKCS1v15(rand.Reader, rsaPrivateKey, crypto.SHA256, hashed[:]); err != nil {
+		return err
+	}
+
+	return nil
+}
 
 func (tc TokenController) GetTokenB2B(privateKey string, clientId string, isProduction bool) tokenModels.TokenB2BResponseDTO {
 	var xtimestamp = TokenServices.GenerateTimestamp()

--- a/doku/snap.go
+++ b/doku/snap.go
@@ -52,6 +52,50 @@ type Snap struct {
 	tokenB2B2CGeneratedTimestamp string
 }
 
+type SnapOption interface {
+	apply(*Snap)
+}
+
+type snapOptionFn func(*Snap)
+
+func (o snapOptionFn) apply(s *Snap)      { o(s) }
+func ProductionEnv() SnapOption           { return snapOptionFn(func(s *Snap) { s.IsProduction = true }) }
+func WithIssuer(issuer string) SnapOption { return snapOptionFn(func(s *Snap) { s.Issuer = issuer }) }
+
+// NewClient creates a new Snap client.
+func NewClient(privateKey, publicKey, secretKey, clientID string, opts ...SnapOption) (*Snap, error) {
+	// initialize controllers if not already set
+	if TokenController == nil {
+		TokenController = controllers.TokenController{}
+	}
+	if VaController == nil {
+		VaController = controllers.VaController{}
+	}
+	if NotificationController == nil {
+		NotificationController = controllers.NotificationController{}
+	}
+	if DirectDebitController == nil {
+		DirectDebitController = &controllers.DirectDebitController{}
+	}
+
+	if err := TokenController.VerifyClientKey(privateKey, clientID); err != nil {
+		return nil, err
+	}
+
+	snap := &Snap{
+		PrivateKey: privateKey,
+		PublicKey:  publicKey,
+		SecretKey:  secretKey,
+		ClientId:   clientID,
+	}
+
+	for _, opt := range opts {
+		opt.apply(snap)
+	}
+
+	return snap, nil
+}
+
 func (snap *Snap) GetTokenB2B() tokenVaModels.TokenB2BResponseDTO {
 	tokenB2BResponseDTO := TokenController.GetTokenB2B(snap.PrivateKey, snap.ClientId, snap.IsProduction)
 	snap.SetTokenB2B(tokenB2BResponseDTO)

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,13 @@ module github.com/PTNUSASATUINTIARTHA-DOKU/doku-golang-library
 go 1.22.2
 
 require (
+	github.com/golang-jwt/jwt/v4 v4.5.0
+	github.com/stretchr/testify v1.9.0
+)
+
+require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/stretchr/testify v1.9.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,7 @@ github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/test/doku_test.go
+++ b/test/doku_test.go
@@ -12,6 +12,15 @@ import (
 var mockGenerated utilsmock.MockGenerated
 var mockController = new(utilsmock.MockController)
 
+func TestNewClient(t *testing.T) {
+	doku.TokenController = mockController
+	mockController.On("VerifyClientKey", "privateKeyPem", "BRN-0221-1693209567392").Return(nil)
+
+	client, err := doku.NewClient("privateKeyPem", "publicKey", "BRN", "BRN-0221-1693209567392", doku.ProductionEnv())
+	assert.NoError(t, err)
+	assert.NotEmpty(t, client)
+}
+
 func TestGetTokenB2BSuccess(t *testing.T) {
 
 	doku.TokenController = mockController

--- a/test/utilsMock/mockController.go
+++ b/test/utilsMock/mockController.go
@@ -28,6 +28,7 @@ type MockController struct {
 }
 
 // TokenController
+func (m *MockController) VerifyClientKey(privateKey, clientID string) error { return nil }
 
 func (m *MockController) GetTokenB2B(privateKey string, clientId string, isProduction bool) models.TokenB2BResponseDTO {
 	args := m.Called(privateKey, clientId, isProduction)


### PR DESCRIPTION
## Problem
When the application starts, we need to make sure the Snap client is valid. If the provided keys (`privateKey`, `publicKey`, `secretKey`, `clientID`) are wrong or misconfigured, the app should fail fast rather than letting invalid clients be used later in API calls.

### Why we need NewClient
- Centralizes **client initialization** (controllers, keys, options) in one place.
- Provides a **constructor-like function** that guarantees a consistent setup.
- Makes it easier for developers using the SDK to get a fully configured client without touching internals.

### Why we verify client key inside NewClient
- **Fail fast at startup** - ensures misconfigured keys stop the app immediately.
- **Safety** - prevents half-baked or invalid clients from being used.
- **Reliability** - guarantees that any Snap client returned by NewClient has already passed validation, so the rest of the system can trust it.